### PR TITLE
feat: add EAST text detector utility + settings params

### DIFF
--- a/.env.offline
+++ b/.env.offline
@@ -19,3 +19,13 @@ USE_FACE_SEG=false
 YUNET_ONNX=models/face/face_detection_yunet_2023mar.onnx
 EAST_PB=models/text/frozen_east_text_detection.pb
 FACE_SEG_ONNX=models/seg/face_parsing_bisenet_512.onnx
+
+USE_EAST_TEXT=true
+EAST_PB=/app/models/text/frozen_east_text_detection.pb
+EAST_CONF_THRESHOLD=0.5
+EAST_NMS_THRESHOLD=0.4
+EAST_MAX_SIDE=1280
+EAST_MIN_SIZE=6
+
+USE_TEXT_EAST=true
+EAST_PB=models/text/frozen_east_text_detection.pb

--- a/app/detectors.py
+++ b/app/detectors.py
@@ -3,6 +3,7 @@ import re
 from typing import List, Dict
 import cv2
 import numpy as np
+import os
 from functools import lru_cache
 try:
     from transformers import pipeline
@@ -115,7 +116,8 @@ def detect_text_pii(
     # hybrid
     return regex_hits + ner_hits
 
-# detectors.py 末尾に（再掲）
+# EAST検出のラッパ関数（環境変数を有効化(True)しとけばTrueになるガード付き）
+
 def detect_text_regions_east(image_bgr):
     if os.getenv("USE_TEXT_EAST", "false").lower() != "true":
         return []

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,3 +1,5 @@
+# app/setttings.py
+
 from pydantic_settings import BaseSettings
 from typing import Optional
 from pydantic import model_validator
@@ -67,6 +69,14 @@ class Settings(BaseSettings):
     
     # DNN 検出の閾値（顔検出で使用）
     dnn_confidence_threshold: float = 0.5
+
+    # EAST（画像内テキスト検出で使用） 
+    use_east_text: bool = False                         # 環境変数: USE_EAST_TEXT=true でEASTを有効化
+    east_pb: Optional[str] = None                       # 環境変数: EAST_PB=/abs/path/to/frozen_east_text_detection.pb
+    east_conf_threshold: float = 0.5                    # EASTのスコア閾値
+    east_nms_threshold: float = 0.4                     # NMSの閾値
+    east_max_side: int = 1280                           # 入力サイズ上限（32の倍数に丸める）
+    east_min_size: int = 6  
     
     class Config:
         env_file = ".env"

--- a/app/text_detect.py
+++ b/app/text_detect.py
@@ -1,5 +1,13 @@
 # app/text_detect.py
 # EAST text detector (CPU / offline). Returns list[(x,y,w,h)] in original image coords.
+
+# 主な中身：
+# _get_east_net(model_path) : EAST(テキスト認識ライブラリ)pb を読み込む 出力をDNNに繋いでいる
+# _east_input_size(w,h,max_side) : 32の倍数に丸める前処理
+# _decode_east(scores, geometry, conf_thr) : OpenCV サンプル
+# detect_text_boxes_east　読み込んだテキストをボックス化　→ 元画像座標系の (x,y,w,h) リストを返す
+# draw_boxes_debug(bgr, boxes) … デバッグ用矩形描画（実際には未だ未使用だが今後使うかも）
+
 from __future__ import annotations
 import os, math
 from typing import List, Tuple


### PR DESCRIPTION
変更点 

app/text_detect.pyの作成

OpenCV EAST (frozen graph) のCPU実装（GPUはmacOSだと確かめられずとりま後で）
detect_text_boxes_east(bgr, ...) -> List[(x,y,w,h)] を提供。
入力を32の倍数にリサイズ

app/main.py
EASTが有効な場合のみ、検出ボックスを使った置換処理を呼べるようにガードを用意。

app/detectors.py
軽微なユーティリティ追加（osのimportなど警告解消）　他はそのまま。

app/settings.py
EAST関連の設定を環境変数対応で追加（既定はOFFにしている）
use_east_text: bool = False ← USE_EAST_TEXT
east_pb: Optional[str] = None ← EAST_PB
east_conf_threshold: float = 0.5 ← EAST_CONF_THRESHOLD
east_nms_threshold: float = 0.4 ← EAST_NMS_THRESHOLD
east_max_side: int = 1280 ← EAST_MAX_SIDE
east_min_size: int = 6 ← EAST_MIN_SIZE


docker-compose.offline.yml
インフラ/実行まわり
api サービスに EAST系の環境変数を追加し、./models:/app/models:ro をマウント
USE_EAST_TEXT="true" でEASTを使用可能

参考: モデルファイルは models/text/frozen_east_text_detection.pb（約90MB）大きすぎるのでリポには含めず、マウントで参照の形をとる

ターミナルのコマンド例

１）ワンショットで確認の場合

docker-compose -f docker-compose.offline.yml exec -T api python - <<'PY'
import os, cv2, numpy as np
from app.text_detect import detect_text_boxes_east
print("EAST_PB =", os.getenv("EAST_PB"))
img = np.full((400,900,3), 255, np.uint8)
cv2.putText(img, "mail: test@example.com", (40,120),
            cv2.FONT_HERSHEY_SIMPLEX, 1.2, (0,0,0), 2)
boxes = detect_text_boxes_east(img)
print("EAST boxes:", len(boxes), boxes[:3])
PY

2)curlでAPI叩いて確認の場合　 テキストボックスで黒塗りの例（style=box）

curl -s -o /tmp/redacted.png \
  -F file=@pii-redactor/pii_demo_sample.png \
  -F policy="email,phone,amount,address" \
  -F style=box \
  http://localhost:8000/redact/replace
open /tmp/redacted.png

